### PR TITLE
Revert "apm-4807 temporarily add a product to test change to common pipelines"

### DIFF
--- a/manifest_template.yml
+++ b/manifest_template.yml
@@ -67,29 +67,6 @@ apigee:
         quota: '300'
         quotaInterval: '1'
         quotaTimeUnit: minute
-{% if ENV.name == 'int' %}
-      - name: {{ NAME }}-temp
-        approvalType: auto
-        attributes:
-          - name: access
-            value: public
-          - name: ratelimit
-            value: 5ps
-        description: {{ DESCRIPTION }} (APM-4807 Testing)
-        displayName: {{ TITLE }} (APM-4807 Testing)
-        environments: [ {{ ENV.name }} ]
-        proxies:
-          - canary-api-{{ ENV.name }}
-          - identity-service-{{ ENV.name }}
-          - identity-service-mock-{{ ENV.name }}
-        scopes:
-          - 'urn:nhsd:apim:app:level3:canary-api'
-          - 'urn:nhsd:apim:user-nhs-id:aal3:canary-api'
-          - 'urn:nhsd:apim:user-nhs-login:P9:canary-api'
-        quota: '300'
-        quotaInterval: '1'
-        quotaTimeUnit: minute
-{% endif %}
     specs:
       - name: {{ NAME }}
         path: canary-api.json

--- a/specification/canary-api.yaml
+++ b/specification/canary-api.yaml
@@ -8,7 +8,7 @@ info:
   title: Canaray-API
   description: |
     ## Overview 
-    This is a copy of the Hello World API spec simply for testing releases to production.
+    This is a copy of the Hello World API spec simply for testing releases to production. DUMMY CHANGE
     
   contact:
     name: API Management Support


### PR DESCRIPTION
Reverts NHSDigital/canary-api#141